### PR TITLE
Fix recipe creation navigation

### DIFF
--- a/foodies-frontend/src/components/forms/AddRecipeForm.js
+++ b/foodies-frontend/src/components/forms/AddRecipeForm.js
@@ -89,7 +89,10 @@ const AddRecipeForm = () => {
         const resultAction = await dispatch(createRecipe(formData));
         if (createRecipe.fulfilled.match(resultAction)) {
           toast.success('Recipe created successfully!');
-          navigate(`/recipe/${resultAction.payload._id}`);
+          const createdRecipe = resultAction.payload?.data ?? resultAction.payload;
+          if (createdRecipe?._id) {
+            navigate(`/recipe/${createdRecipe._id}`);
+          }
         } else {
           toast.error(resultAction.payload || 'Failed to create recipe');
         }

--- a/foodies-frontend/src/store/slices/recipesSlice.js
+++ b/foodies-frontend/src/store/slices/recipesSlice.js
@@ -46,7 +46,7 @@ export const createRecipe = createAsyncThunk(
           'Content-Type': 'multipart/form-data',
         },
       });
-      return response.data;
+      return response.data.data;
     } catch (error) {
       return rejectWithValue(error.response?.data?.error || error.message);
     }
@@ -175,7 +175,9 @@ const recipesSlice = createSlice({
       })
       .addCase(createRecipe.fulfilled, (state, action) => {
         state.loading = false;
-        state.recipes.unshift(action.payload.data);
+        if (action.payload) {
+          state.recipes.unshift(action.payload);
+        }
       })
       .addCase(createRecipe.rejected, (state, action) => {
         state.loading = false;


### PR DESCRIPTION
## Summary
- ensure the add recipe form reads the created recipe id before navigating to the recipe details page
- adjust the createRecipe thunk to return the created recipe object and update the slice to store it directly

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d5b595e9fc832aabbad50ea9c7e501